### PR TITLE
Add details about beforeEach

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ test('it redirects when clicking the button', async function(assert) {
 Note the import and use of the `lookupWindow` helper provided by this addon to get access to the window service instance
 in your test.
 
-## Integration tests
+## Integration/Unit tests
+
+**Note:** You *must* use `mockWindow` in your `beforeEach` or your tests will fail with `Attempting to inject an unknown injection: 'service:window'`
 
 In integration tests the initializer will not be executed automatically, so you can use the `mockWindow` helper to 
 register the mocked service instead of the normal one. 


### PR DESCRIPTION
I was getting errors for `Attempting to inject an unknown injection: 'service:window'` in my unit tests and it was not apparent to me that it was required to do the window mock. I thought it was only if you wanted to test it. Figured adding these details might help others.