### PR TITLE
add failing test for side effects

### DIFF
--- a/tests/integration/window-test.js
+++ b/tests/integration/window-test.js
@@ -25,3 +25,19 @@ test('it can mock window in integration tests', async function(assert) {
 
   assert.equal(window.location.href, 'http://www.example.com');
 });
+
+test('each test gets a fresh copy - part 1 of 2', function(assert) {
+  let window = lookupWindow(this);
+
+  assert.notEqual(window.location.href, 'http://www.example.com');
+
+  window.location.href = 'http://www.example.com';
+});
+
+test('each test gets a fresh copy - part 2 of 2', function(assert) {
+  let window = lookupWindow(this);
+
+  assert.notEqual(window.location.href, 'http://www.example.com');
+
+  window.location.href = 'http://www.example.com';
+});


### PR DESCRIPTION
Unless I'm misunderstanding the purpose of this mock, each test should have a fresh copy of the mock as to prevent race conditions. Currently, changes to the mock persist across tests.