### PR TITLE
Fix side effects

### DIFF
--- a/addon-test-support/-private/mock-window.js
+++ b/addon-test-support/-private/mock-window.js
@@ -1,4 +1,4 @@
-import WindowMockService from './services/window';
+import windowMockFactory from './services/window';
 
 export function mockWindow(scope) {
   if (!scope) {
@@ -7,5 +7,5 @@ export function mockWindow(scope) {
   if (!scope.register) {
     throw new Error('mockWindow must be called from an integration test!');
   }
-  return scope.register('service:window', WindowMockService, { instantiate: false });
+  return scope.register('service:window', windowMockFactory(), { instantiate: false });
 }

--- a/addon-test-support/-private/mock/location.js
+++ b/addon-test-support/-private/mock/location.js
@@ -8,110 +8,114 @@ import parseUri from './parse-uri';
  * @type {Object}
  * @public
  */
-const location = {};
 
-Object.defineProperty(location, 'href', {
-  value: '',
-  enumerable: true,
-  writable: true
-});
 
-/**
- * location.port
- */
-Object.defineProperty(location, 'port', {
-  get() {
-    return parseUri(this.href).port;
-  },
-  set(port) {
-    let old = this.port;
-    this.href = this.href.replace(old, port);
-  },
-  enumerable: true
-});
+export default function locationFactory() {
+  const location = {};
 
-/**
- * location.host
- */
-Object.defineProperty(location, 'host', {
-  get() {
-    return this.port ? `${this.hostname}:${this.port}` : this.hostname;
-  },
-  set(host) {
-    let old = this.host;
-    this.href = this.href.replace(old, host);
-  },
-  enumerable: true
-});
+  Object.defineProperty(location, 'href', {
+    value: '',
+    enumerable: true,
+    writable: true
+  });
 
-/**
- * location.hostname
- * @returns {String} host + port
- */
-Object.defineProperty(location, 'hostname', {
-  get() {
-    return parseUri(this.href).host;
-  },
-  set(hostname) {
-    let old = this.hostname;
-    this.href = this.href.replace(old, hostname);
-  }
-});
+  /**
+   * location.port
+   */
+  Object.defineProperty(location, 'port', {
+    get() {
+      return parseUri(this.href).port;
+    },
+    set(port) {
+      let old = this.port;
+      this.href = this.href.replace(old, port);
+    },
+    enumerable: true
+  });
 
-/**
- * location.hash
- */
-Object.defineProperty(location, 'hash', {
-  get() {
-    let hash = parseUri(this.href).anchor;
-    return hash ? `#${hash}` : '';
-  },
-  set(hash) {
-    let old = this.hash;
-    this.href = this.href.replace(old, hash);
-  }
-});
+  /**
+   * location.host
+   */
+  Object.defineProperty(location, 'host', {
+    get() {
+      return this.port ? `${this.hostname}:${this.port}` : this.hostname;
+    },
+    set(host) {
+      let old = this.host;
+      this.href = this.href.replace(old, host);
+    },
+    enumerable: true
+  });
 
-/**
- * location.origin
- */
-Object.defineProperty(location, 'origin', {
-  get() {
-    return `${this.protocol}//${this.host}`;
-  },
-  set(origin) {
-    let old = this.origin;
-    this.href = this.href.replace(old, origin);
-  }
-});
+  /**
+   * location.hostname
+   * @returns {String} host + port
+   */
+  Object.defineProperty(location, 'hostname', {
+    get() {
+      return parseUri(this.href).host;
+    },
+    set(hostname) {
+      let old = this.hostname;
+      this.href = this.href.replace(old, hostname);
+    }
+  });
 
-/**
- * location.origin
- */
-Object.defineProperty(location, 'search', {
-  get() {
-    let q = parseUri(this.href).query;
-    return q ? `?${q}` : '';
-  },
-  set(search) {
-    let old = this.search;
-    this.href = this.href.replace(old, search);
-  }
-});
+  /**
+   * location.hash
+   */
+  Object.defineProperty(location, 'hash', {
+    get() {
+      let hash = parseUri(this.href).anchor;
+      return hash ? `#${hash}` : '';
+    },
+    set(hash) {
+      let old = this.hash;
+      this.href = this.href.replace(old, hash);
+    }
+  });
 
-/**
- * location.protocol
- */
-Object.defineProperty(location, 'protocol', {
-  get() {
-    return `${parseUri(this.href).protocol}:`;
-  },
-  set(protocol) {
-    let old = this.protocol;
-    this.href = this.href.replace(old, protocol);
-  }
-});
-location.reload = function() {};
-location.replace = function() {};
+  /**
+   * location.origin
+   */
+  Object.defineProperty(location, 'origin', {
+    get() {
+      return `${this.protocol}//${this.host}`;
+    },
+    set(origin) {
+      let old = this.origin;
+      this.href = this.href.replace(old, origin);
+    }
+  });
 
-export default location;
+  /**
+   * location.origin
+   */
+  Object.defineProperty(location, 'search', {
+    get() {
+      let q = parseUri(this.href).query;
+      return q ? `?${q}` : '';
+    },
+    set(search) {
+      let old = this.search;
+      this.href = this.href.replace(old, search);
+    }
+  });
+
+  /**
+   * location.protocol
+   */
+  Object.defineProperty(location, 'protocol', {
+    get() {
+      return `${parseUri(this.href).protocol}:`;
+    },
+    set(protocol) {
+      let old = this.protocol;
+      this.href = this.href.replace(old, protocol);
+    }
+  });
+  location.reload = function() {};
+  location.replace = function() {};
+
+  return location;
+}

--- a/addon-test-support/-private/services/window.js
+++ b/addon-test-support/-private/services/window.js
@@ -1,25 +1,27 @@
-import location from '../mock/location';
+import locationFactory from '../mock/location';
 
 function noop() {}
 
-const ProxyWindow = new Proxy(window, {
-  get(target, name) {
-    switch (name) {
-      case 'location':
-        return location;
-      case 'alert':
-      case 'confirm':
-      case 'prompt':
-        return noop;
-      default:
-        if (target.hasOwnProperty(name) && typeof target[name] === 'function') {
-          return target[name].bind(target);
-        }
-        return target[name];
+export default function windowMockFactory() {
+  let location = locationFactory();
+
+  let ProxyWindow = new Proxy(window, {
+    get(target, name) {
+      switch (name) {
+        case 'location':
+          return location;
+        case 'alert':
+        case 'confirm':
+        case 'prompt':
+          return noop;
+        default:
+          if (target.hasOwnProperty(name) && typeof target[name] === 'function') {
+            return target[name].bind(target);
+          }
+          return target[name];
+      }
     }
-  }
-});
+  });
 
-const MockWindow = Object.create(ProxyWindow);
-
-export default MockWindow;
+  return Object.create(ProxyWindow);
+}

--- a/addon/-private/services/window.js
+++ b/addon/-private/services/window.js
@@ -1,1 +1,1 @@
-export default window;
+export default () => window;

--- a/addon/initializers/window-service.js
+++ b/addon/initializers/window-service.js
@@ -1,7 +1,7 @@
-import WindowService from 'ember-window-mock/-private/services/window';
+import windowFactory from 'ember-window-mock/-private/services/window';
 
 export function initialize(application) {
-  application.register('service:window', WindowService, { instantiate: false });
+  application.register('service:window', windowFactory(), { instantiate: false });
 }
 
 export default {

--- a/tests/integration/window-test.js
+++ b/tests/integration/window-test.js
@@ -25,3 +25,19 @@ test('it can mock window in integration tests', async function(assert) {
 
   assert.equal(window.location.href, 'http://www.example.com');
 });
+
+test('each test gets a fresh copy - part 1 of 2', function(assert) {
+  let window = lookupWindow(this);
+
+  assert.notEqual(window.location.href, 'http://www.example.com');
+
+  window.location.href = 'http://www.example.com';
+});
+
+test('each test gets a fresh copy - part 2 of 2', function(assert) {
+  let window = lookupWindow(this);
+
+  assert.notEqual(window.location.href, 'http://www.example.com');
+
+  window.location.href = 'http://www.example.com';
+});

--- a/tests/unit/services/window-mock-test.js
+++ b/tests/unit/services/window-mock-test.js
@@ -2,63 +2,66 @@ import { module } from 'ember-qunit';
 import test from 'ember-sinon-qunit/test-support/test';
 import windowMock from 'ember-window-mock/-private/services/window';
 
-module('service:window-mock', 'Unit | Service | window mock', {
+module('service:window-mock', {
+  beforeEach() {
+    this.windowMock = windowMock();
+  }
 });
 
 test('it mocks window.location', function(assert) {
-  windowMock.location.href = 'http://www.example.com';
-  assert.equal(windowMock.location.href, 'http://www.example.com');
-  assert.equal(windowMock.location.host, 'www.example.com');
-  assert.equal(windowMock.location.protocol, 'http:');
+  this.windowMock.location.href = 'http://www.example.com';
+  assert.equal(this.windowMock.location.href, 'http://www.example.com');
+  assert.equal(this.windowMock.location.host, 'www.example.com');
+  assert.equal(this.windowMock.location.protocol, 'http:');
 });
 
 test('it proxies properties', function(assert) {
   window.window_mock_test_property = 'foo';
-  assert.equal(windowMock.window_mock_test_property, 'foo');
+  assert.equal(this.windowMock.window_mock_test_property, 'foo');
   delete window.window_mock_test_property;
 });
 
 test('it proxies functions', function(assert) {
   assert.expect(1);
-  windowMock.focus();
+  this.windowMock.focus();
   assert.ok(true);
 });
 
 test('it replaces alert with noop', function(assert) {
   assert.expect(1);
-  assert.equal(windowMock.alert('foo'), undefined);
+  assert.equal(this.windowMock.alert('foo'), undefined);
 });
 
 test('it replaces confirm with noop', function(assert) {
   assert.expect(1);
-  assert.equal(windowMock.confirm('foo'), undefined);
+  assert.equal(this.windowMock.confirm('foo'), undefined);
 });
 
 test('it replaces prompt with prompt', function(assert) {
   assert.expect(1);
-  assert.equal(windowMock.prompt('foo'), undefined);
+  assert.equal(this.windowMock.prompt('foo'), undefined);
 });
 
 test('it can stub alert', function(assert) {
-  let stub = this.stub(windowMock, 'alert');
-  windowMock.alert('foo');
+  let stub = this.stub(this.windowMock, 'alert');
+  this.windowMock.alert('foo');
   assert.ok(stub.calledOnce);
   assert.ok(stub.calledWith('foo'));
 });
 
 test('it can stub confirm', function(assert) {
-  let stub = this.stub(windowMock, 'confirm');
+  let stub = this.stub(this.windowMock, 'confirm');
   stub.returns(true);
-  let result = windowMock.confirm('foo');
+  let result = this.windowMock.confirm('foo');
   assert.ok(stub.calledOnce);
   assert.ok(stub.calledWith('foo'));
   assert.equal(result, true);
 });
 
 test('it can stub prompt', function(assert) {
-  let stub = this.stub(windowMock, 'prompt');
+  let stub = this.stub(this.windowMock, 'prompt');
   stub.returns('bar');
-  let result = windowMock.prompt('foo');
+  let result = this.windowMock.prompt('foo');
   assert.ok(stub.calledOnce);
   assert.ok(stub.calledWith('foo'));
   assert.equal(result, 'bar');


### PR DESCRIPTION
Create a fresh mock object for every call of `mockWindow()`. Should fix #10 
cc @kellyselden