### PR TITLE
Support scope.register and the new scope.owner.register

### DIFF
--- a/addon-test-support/-private/mock-window.js
+++ b/addon-test-support/-private/mock-window.js
@@ -15,5 +15,5 @@ export function mockWindow(scope) {
     throw new Error('mockWindow must be called from an unit/integration test!');
   }
   
-  return register.call(this, 'service:window', windowMockFactory(), { instantiate: false });
+  return register.call(scope, 'service:window', windowMockFactory(), { instantiate: false });
 }

--- a/addon-test-support/-private/mock-window.js
+++ b/addon-test-support/-private/mock-window.js
@@ -4,8 +4,16 @@ export function mockWindow(scope) {
   if (!scope) {
     throw new Error('mockWindow must be called with `this` as the first function parameter!');
   }
-  if (!scope.register) {
-    throw new Error('mockWindow must be called from an integration test!');
+  
+  let register = scope.register;
+  
+  if(scope.owner && scope.owner.register) {
+    register = scope.owner.register;
   }
-  return scope.register('service:window', windowMockFactory(), { instantiate: false });
+  
+  if (!register) {
+    throw new Error('mockWindow must be called from an unit/integration test!');
+  }
+  
+  return register('service:window', windowMockFactory(), { instantiate: false });
 }

--- a/addon-test-support/-private/mock-window.js
+++ b/addon-test-support/-private/mock-window.js
@@ -15,5 +15,5 @@ export function mockWindow(scope) {
     throw new Error('mockWindow must be called from an unit/integration test!');
   }
   
-  return register('service:window', windowMockFactory(), { instantiate: false });
+  return register.call(this, 'service:window', windowMockFactory(), { instantiate: false });
 }


### PR DESCRIPTION
According to http://rwjblue.com/2017/10/23/ember-qunit-simplication/ `this.register` is now `this.owner.register`, so I am getting errors trying to use the new test syntax.