### PR TITLE
Update lookup-window.js to work with mocha

### DIFF
--- a/addon-test-support/-private/lookup-window.js
+++ b/addon-test-support/-private/lookup-window.js
@@ -1,5 +1,5 @@
 export function lookupWindow(scope) {
-  let container = scope.container || (scope.application && scope.application.__container__);
+  let container = scope.container || (scope.application && scope.application.__container__) || scope.__container__;
   if (!container) {
     throw new Error('No container found to lookup service from!');
   }


### PR DESCRIPTION
## Why

The ember-cli-mocha acceptance test blueprint does not work with lookup-window.

```js
import { describe, it, beforeEach, afterEach } from 'mocha';
import { expect } from 'chai';
import startApp from 'my-app/tests/helpers/start-app';
import destroyApp from 'my-app/tests/helpers/destroy-app';

import { lookupWindow } from 'ember-window-mock';


describe('Acceptance | homebot email authentication', function() {
  let application;

  beforeEach(function() {
    application = startApp();
  });

  afterEach(function() {
    destroyApp(application);
  });

  it('redirects to our the login service', function() {
    let window = lookupWindow(application);
    visit('/auth/success');

    return andThen(() => {
      expect(window.location.href).to.equal('http://localhost/login');
    });
  });
});
```

## Changes

Allow `lookupWindow` to accept the application itself.