### PR TITLE
Add test for calling dispatchEvent

### DIFF
--- a/tests/integration/window-test.js
+++ b/tests/integration/window-test.js
@@ -1,8 +1,7 @@
-import { moduleForComponent } from 'ember-qunit';
+import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { lookupWindow, mockWindow } from 'ember-window-mock';
 import { click } from 'ember-native-dom-helpers';
-import test from 'ember-sinon-qunit/test-support/test';
 
 moduleForComponent('window', 'Integration | window', {
   integration: true,
@@ -41,13 +40,4 @@ test('each test gets a fresh copy - part 2 of 2', function(assert) {
   assert.notEqual(window.location.href, 'http://www.example.com/');
 
   window.location.href = 'http://www.example.com/';
-});
-
-test('it can call dispatchEvent', function(assert) {
-  let window = lookupWindow(this);
-  assert.expect(1);
-  let spy = this.spy();
-  window.addEventListener('test-event', spy);
-  window.dispatchEvent(new Event('test-event'));
-  assert.ok(spy.calledOnce);
 });

--- a/tests/integration/window-test.js
+++ b/tests/integration/window-test.js
@@ -1,7 +1,8 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { moduleForComponent } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { lookupWindow, mockWindow } from 'ember-window-mock';
 import { click } from 'ember-native-dom-helpers';
+import test from 'ember-sinon-qunit/test-support/test';
 
 moduleForComponent('window', 'Integration | window', {
   integration: true,
@@ -40,4 +41,13 @@ test('each test gets a fresh copy - part 2 of 2', function(assert) {
   assert.notEqual(window.location.href, 'http://www.example.com/');
 
   window.location.href = 'http://www.example.com/';
+});
+
+test('it can call dispatchEvent', function(assert) {
+  let window = lookupWindow(this);
+  assert.expect(1);
+  let spy = this.spy();
+  window.addEventListener('test-event', spy);
+  window.dispatchEvent(new Event('test-event'));
+  assert.ok(spy.calledOnce);
 });

--- a/tests/unit/services/window-mock-test.js
+++ b/tests/unit/services/window-mock-test.js
@@ -132,3 +132,11 @@ test('it allows retrieving sinon functions from the proxy', function(assert) {
   this.windowMock.testFn = this.spy();
   assert.ok(this.windowMock.testFn.reset);
 });
+
+test('it can call dispatchEvent', function(assert) {
+  assert.expect(1);
+  let spy = this.spy();
+  this.windowMock.addEventListener('test-event', spy);
+  this.windowMock.dispatchEvent(new Event('test-event'));
+  assert.ok(spy.calledOnce);
+});


### PR DESCRIPTION
Add a test to call `window.dispatchEvent`. This fails in tests with an `Illegal invocation` error but works in normal code execution.

See issue:
https://github.com/kaliber5/ember-window-mock/issues/36

The test is an integration test. Does that seem appropriate? The same behavior can be seen with a unit test.