### PR TITLE
Fix invocation error for window.dispatchEvent

### DIFF
--- a/addon-test-support/-private/services/window.js
+++ b/addon-test-support/-private/services/window.js
@@ -19,7 +19,7 @@ export default function windowMockFactory() {
           if (name in holder) {
             return holder[name];
           }
-          if (window.hasOwnProperty(name) && typeof window[name] === 'function') {
+          if (typeof window[name] === 'function') {
             return window[name].bind(window);
           }
           return target[name];


### PR DESCRIPTION
It is not an "ownProperty", at least in Chrome (comes through "EventTarget" in the prototype chain). The previous check is not needed anyway, as setting a custom function is now down on the holder object.

Fixes #36