### PR TITLE
feat: add method to setup window reset on test hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ import { reset } from 'ember-window-mock';
 
 This function should be called before all tests that depend on the window mock, preferably in the `beforeEach` hook. See below for some examples!
 
+### Resetting the state with the new testing api
+
+If your test are using the QUnit 2.0 test syntax, introduced in [RFC 0232](https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md),
+then you can setup window mock by calling the `setupWindowMock` method:
+
+```js
+import {setupWindowMock} from 'ember-window-mock';
+
+module('SidebarController', function(hooks) {
+  setupWindowMock(hooks);
+
+  test(...);
+});
+```
+
 ## Test examples
 
 ### Mocking `window.location`

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ import { reset } from 'ember-window-mock';
 
 This function should be called before all tests that depend on the window mock, preferably in the `beforeEach` hook. See below for some examples!
 
-### Resetting the state with the new testing api
+### Resetting the state with the new testing APIs
 
-If your test are using the QUnit 2.0 test syntax, introduced in [RFC 0232](https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md),
+If your tests are using the QUnit 2.0 test syntax, introduced in [RFC 0232](https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md),
 then you can setup window mock by calling the `setupWindowMock` method:
 
 ```js
-import {setupWindowMock} from 'ember-window-mock';
+import { setupWindowMock } from 'ember-window-mock';
 
 module('SidebarController', function(hooks) {
   setupWindowMock(hooks);

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,1 +1,2 @@
 export { default, reset } from './-private/window';
+export { default as setupWindowMock} from './setup-window-mock';

--- a/addon-test-support/setup-window-mock.js
+++ b/addon-test-support/setup-window-mock.js
@@ -1,0 +1,10 @@
+import { reset } from 'ember-window-mock';
+
+//
+// Used to reset window-mock for a test.
+//
+// NOTE: the `hooks = self` is for mocha support
+//
+export default function setupWindowMock(hooks = self) {
+  hooks.beforeEach(reset);
+}

--- a/tests/unit/setup-window-mock-test.js
+++ b/tests/unit/setup-window-mock-test.js
@@ -1,0 +1,15 @@
+import sinonTest from 'ember-sinon-qunit/test-support/test';
+import {reset, setupWindowMock} from 'ember-window-mock';
+import { module } from 'qunit';
+
+module('setup-window-mock', function () {
+  sinonTest('it calls reset in the hooks', function (assert) {
+    const _hooks = {
+      beforeEach: this.spy(),
+    };
+
+    setupWindowMock(_hooks);
+
+    assert.ok(_hooks.beforeEach.calledWith(reset));
+  });
+});


### PR DESCRIPTION
fixes #57

I'm actually not sure if the note about mocha is true.
I found that part when looking at the [mirage setup method](https://github.com/samselikoff/ember-cli-mirage/blob/master/addon-test-support/setup-mirage.js#L9).

The name and documentation isn't final. If anyone has better suggestions, please tell :smiley: 