### PR TITLE
Ember engine workaround

### DIFF
--- a/addon-test-support/-private/mock/location.js
+++ b/addon-test-support/-private/mock/location.js
@@ -21,6 +21,10 @@ const mappedPorperties = [
  * @public
  */
 export default function locationFactory(defaultUrl) {
+  if (!defaultUrl) {
+    defaultUrl = window.location.href;
+  }
+
   let location = {};
   let url = new URL(defaultUrl);
 


### PR DESCRIPTION
This works with an engine installed in the app that is running the tests?

We have been using this work around for a number of months. 

Address #53 
@kellyselden would you have any suggestions on how to get a url from the engine?