### PR TITLE
fix(setup-window-mock): reset in `afterEach` hook

### DIFF
--- a/addon-test-support/-private/setup-window-mock.js
+++ b/addon-test-support/-private/setup-window-mock.js
@@ -6,5 +6,6 @@ import { reset } from 'ember-window-mock';
 // NOTE: the `hooks = self` is for mocha support
 //
 export default function setupWindowMock(hooks = self) {
-  hooks.beforeEach(reset);
+  // @TODO: assert that window mock is pristine in `hooks.before`.
+  hooks.afterEach(reset);
 }

--- a/tests/unit/setup-window-mock-test.js
+++ b/tests/unit/setup-window-mock-test.js
@@ -7,11 +7,11 @@ module('setup-window-mock', function(hooks) {
 
   test('it calls reset in the hooks', function(assert) {
     const _hooks = {
-      beforeEach: this.sandbox.spy(),
+      afterEach: this.sandbox.spy(),
     };
 
     setupWindowMock(_hooks);
 
-    assert.ok(_hooks.beforeEach.calledWith(reset));
+    assert.ok(_hooks.afterEach.calledWith(reset));
   });
 });


### PR DESCRIPTION
Runs the `reset` in `afterEach` to clean up the `window` mock after every test. This assumes that all preceding tests did not leak state and the test module starts with a pristine `window` mock.

This PR _could_ potentially make your tests fail. If so, you somewhere have a leaky preceding test.

---

I have some tests which indirectly depend on the default state of the global `window` mock (all imported via `ember-window-mock`) and they started failing after I mutated that state in an unrelated test.

While I _technically could_ and _probably should_ (?) call `setupWindowMock` in the failing tests as well, I think it would be easiest and safest, if every test module would clean up after itself and reset the global `window` mock back to its default state.