### PR TITLE
add window.open() example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,28 @@ test('it deletes an item', async function(assert) {
   assert.ok(stub.calledWith('Are you sure?'));
 });
 ``` 
+
+### Mocking `open()`
+
+Here is an example that assigns a new function to replace `open`.
+You can check if the function has been called as well as the value of its parameters.
+
+```js
+import { module, test } from 'qunit';
+import { click, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { default as window, reset } from 'ember-window-mock';
+
+module('Acceptance | new window', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('it opens a new window when clicking the button', async function(assert) {
+    await visit('/');
+    window.open = (urlToOpen) => {
+      assert.equal(urlToOpen, 'http://www.example.com/some-file.jpg');
+    };
+    await click('button');
+    reset();
+  });
+}
+```


### PR DESCRIPTION
Following the question I asked in #93;
I propose to document the example of mocking `window.open()`.
I didn't know it could be done without relying on a mocking library like Sinon.js.