### PR TITLE
fix: make `reset` assertion work

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -3,5 +3,5 @@ import { assert } from '@ember/debug';
 export default window;
 
 export function reset() {
-  assert('reset() is only available in tests', true);
+  assert('reset() is only available in tests');
 }


### PR DESCRIPTION
This assertion would never have been triggered before.

https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/assert