### PR TITLE
fix: reset to `doNothingHandler`

### DIFF
--- a/addon-test-support/-private/setup-window-mock.js
+++ b/addon-test-support/-private/setup-window-mock.js
@@ -10,6 +10,6 @@ export default function setupWindowMock(hooks = self) {
   hooks.beforeEach(() => _setCurrentHandler(mockProxyHandler))
   hooks.afterEach(() => {
     reset();
-    _setCurrentHandler(null);
+    _setCurrentHandler();
   });
 }


### PR DESCRIPTION
When the tests are finished, rather than replacing the handler with `null`, it makes more sense to reset the handler back to the default handler. This can be achieved by passing nothing (aka `undefined`) to the `setCurrentHandler` function, as it'll fall back to the default value.

Our test suite is getting a bunch of instances of trying to call methods on `null` when trying to upgrade to `0.7.0`, and I _think_ the reset to `null` here is the culprit. It's pretty tough to track down which test suite is not mocking the window correctly, but I think this change would get us un-stuck!