### PR TITLE
Add tests for (nested) setupWindowMock calls

### DIFF
--- a/tests/unit/setup-window-mock-test.js
+++ b/tests/unit/setup-window-mock-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import mockableWindow from 'ember-window-mock';
+import { setupWindowMock } from 'ember-window-mock/test-support';
+
+function testIsMocked(message) {
+  test(message, function(assert) {
+    mockableWindow.localStorage.setItem('foo', 'bar');
+    assert.equal(mockableWindow.localStorage.getItem('foo'), 'bar');
+    assert.equal(window.localStorage.getItem('foo'), null);
+  });
+}
+
+function testIsResetted() {
+  test('mocked state is resetted after test', function(assert) {
+    assert.equal(mockableWindow.localStorage.getItem('foo'), null);
+  });
+}
+
+function testIsNOTMocked(message) {
+  test(message, function(assert) {
+    mockableWindow.localStorage.setItem('foo', 'bar');
+    assert.equal(mockableWindow.localStorage.getItem('foo'), 'bar');
+    assert.equal(window.localStorage.getItem('foo'), 'bar');
+    mockableWindow.localStorage.removeItem('foo');
+  });
+}
+
+module('setup-window-mock', function() {
+
+  module('single', function() {
+    module('module', function(hooks) {
+      setupWindowMock(hooks);
+
+      testIsMocked('window is mocked when test is inside setupWindowMock');
+    });
+
+    testIsResetted();
+    testIsNOTMocked('window is *not* mocked when test is *outside* setupWindowMock');
+  });
+
+  module('nested', function() {
+    module('outer module', function(hooks) {
+      setupWindowMock(hooks);
+
+      module('inner module', function(hooks) {
+        setupWindowMock(hooks);
+
+        testIsMocked('window is mocked when test is inside inner setupWindowMock');
+      });
+
+      testIsResetted();
+      testIsMocked('window is mocked when test is inside outer setupWindowMock');
+    });
+
+    testIsResetted();
+    testIsNOTMocked('window is *not* mocked when test is *outside* setupWindowMock');
+  });
+});


### PR DESCRIPTION
This adds better test coverage for calls to `setupWindowMock()`, specifically the nested usage discussed with @rwjblue in https://github.com/kaliber5/ember-window-mock/pull/191#discussion_r454379796.

It turned out that the current implementation (after being fixed by @alexlafroscia in #201) already supports the nested case properly, as the `mockHandler` is set up in the `beforeEach` hook, so as long as there is any nested `setupWindowMock()` the window object will be mocked, and only when a test is not somehow wrapped in a setup call will it see the unmocked window.

Closes #207 