### PR TITLE
Remove disabling the ember-window-mock embroider compat adapter

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -17,9 +17,7 @@ module.exports = function(defaults) {
   if ('@embroider/webpack' in app.dependencies()) {
     const { Webpack } = require('@embroider/webpack'); // eslint-disable-line node/no-missing-require
     return require('@embroider/compat') // eslint-disable-line node/no-missing-require
-      .compatBuild(app, Webpack, {
-        compatAdapters: new Map([['ember-window-mock', null]])
-      });
+      .compatBuild(app, Webpack);
   } else {
     return app.toTree();
   }


### PR DESCRIPTION
As the new embroider release does not have that adapter anymore.